### PR TITLE
add support for user-cu-build.config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log
 /lib/
 /interface-lib/
 /cu-boilerplate-module
+/user-cu-build.config.js

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ cu-ui
 
 > Camelot Unchained UI 2.0
 
-This repository contains all of the UI widgets in [Camelot Unchained](http://camelotunchained.com/v2/). This is the entire front-end UI for the game, not a partial stripped-down version. This is what we're going to ship and we will take pull requests from the community seriously.
+This repository contains all of the UI widgets in [Camelot Unchained](http://camelotunchained.com/v2/).
+This is the entire front-end UI for the game, not a partial stripped-down version.
+This is what we're going to ship and we will take pull requests from the community seriously.
 
 ---
 
@@ -45,8 +47,7 @@ This will build all the modules/libraries into the `publish` directory ready for
 
 #### `gulp server`
 
-This will start a server to preview all the modules/libraries. It will also inject a fake `cuAPI` into all pages,
-so things don't break outside of the client.
+This will start a server to preview all the modules/libraries. It will also inject scripts declared in the build config.
 
 #### `gulp %MODULE%`
 
@@ -70,6 +71,25 @@ Or if you want to target a specific channel you can add the channel number to th
 
 ```
 --user-ui 10
+```
+
+Overriding `cu-build.config.js`
+-----------------------------
+
+You can override configuration in `cu-build.config.js` by creating a file called
+`user-cu-build.config.js` and exporting override configuration.
+
+Example:
+
+```js
+// user-cu-build.config.js
+
+module.exports = {
+  publish: {
+    dest: __dirname + '/my-custom-publish-directory',
+  }
+};
+
 ```
 
 ---

--- a/cu-build.config.js
+++ b/cu-build.config.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-module.exports = {
+var config = {
   type: 'multi',
   path: __dirname,
   name: 'cu-ui',
@@ -29,3 +29,14 @@ module.exports = {
     'cu-stores': 'https://github.com/CUModSquad/cu-stores.git#master',
   }
 };
+
+// load user config and merge it with default config if it exists
+var extend = require('extend');
+var fs = require('fs');
+var userConfig = {};
+if (fs.existsSync(__dirname + '/user-cu-build.config.js')) {
+  userConfig = require(__dirname + '/user-cu-build.config.js');
+}
+config = extend(true, config, userConfig);
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "cu-build-tools": "^0.1.8",
-    "gulp": "^3.9.0"
+    "gulp": "^3.9.0",
+    "extend": "^3.0.0"
   }
 }


### PR DESCRIPTION
You can override configuration in `cu-build.config.js` by creating a file called
`user-cu-build.config.js` and exporting override configuration.

Example:

``` js
// user-cu-build.config.js

module.exports = {
  publish: {
    dest: __dirname + '/my-custom-publish-directory',
  }
};

```
