### PR TITLE
Changed the pattern for node_modules exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .suo
 npm-debug.log
 .sublime-gulp.cache
-/node_modules
+**/*node_modules
 /bin
 /obj
 /tmp


### PR DESCRIPTION
using a root selector will only exclude node_modules at the root of the project, but
since we have nested node_modules it really should be using a *_/_ pattern.

I suspect we may need to double check other root level selectors as well.
