### PR TITLE
cleanup tsconfig, migrate styles to client library

### DIFF
--- a/character/src/index.html
+++ b/character/src/index.html
@@ -6,7 +6,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <head>
   <meta charset="UTF-8">
   <title>wounds player</title>
-  <link rel="stylesheet" href="../../interface-lib/cu-components/cu-components.css">
+  <link rel="stylesheet" href="../../interface-lib/camelot-unchained/camelot-unchained.css">
   <link rel="stylesheet" href="css/character.css">
 </head>
 <body>

--- a/character/src/sass/main.scss
+++ b/character/src/sass/main.scss
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-@import "../../node_modules/camelot-unchained/lib/sass/main";
+@import "../../node_modules/camelot-unchained/lib/styles/window/woundsframe/woundsframe";
 
 body {
   @include wounds-body(100%);

--- a/character/tsconfig.json
+++ b/character/tsconfig.json
@@ -1,40 +1,35 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "noImplicitAny": true,
-        "removeComments": false,
-        "outDir": "./tmp",
-        "sourceMap": false,
-        "jsx": "react"
-    },
-    "formatCodeOptions": {
-        "indentSize": 2,
-        "tabSize": 2,
-        "newLineCharacter": "\r\n",
-        "convertTabsToSpaces": true,
-        "insertSpaceAfterCommaDelimiter": true,
-        "insertSpaceAfterSemicolonInForStatements": true,
-        "insertSpaceBeforeAndAfterBinaryOperators": true,
-        "insertSpaceAfterKeywordsInControlFlowStatements": true,
-        "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-        "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
-        "placeOpenBraceOnNewLineForFunctions": false,
-        "placeOpenBraceOnNewLineForControlBlocks": false
-    },
-    "compileOnSave": false,
-    "buildOnSave": false,
-    "filesGlob": [
-        "./src/**/*.ts",
-        "./src/**/*.tsx"
-    ],
-    "files": [
-        "./src/tsd/react/react-dom.d.ts",
-        "./src/tsd/react/react.d.ts",
-        "./src/tsd/tsd.d.ts",
-        "./src/ts/main.tsx"
-    ],
-    "exclude": [],
-    "atom": {
-        "rewriteTsconfig": true
-    }
+  "compilerOptions": {
+    "target": "es6",
+    "noImplicitAny": true,
+    "removeComments": false,
+    "outDir": "./tmp",
+    "sourceMap": false,
+    "jsx": "react"
+  },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2,
+    "newLineCharacter": "\r\n",
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "filesGlob": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/enemytarget/src/index.html
+++ b/enemytarget/src/index.html
@@ -6,7 +6,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <head>
   <meta charset="UTF-8">
   <title>wounds hostile</title>
-  <link rel="stylesheet" href="../../interface-lib/cu-components/cu-components.css">
+  <link rel="stylesheet" href="../../interface-lib/camelot-unchained/camelot-unchained.css">
   <link rel="stylesheet" href="css/enemytarget.css">
 </head>
 <body>

--- a/enemytarget/src/sass/main.scss
+++ b/enemytarget/src/sass/main.scss
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-@import "../../node_modules/camelot-unchained/lib/sass/main";
+@import "../../node_modules/camelot-unchained/lib/styles/window/woundsframe/woundsframe";
 
 body {
   @include wounds-body(90%);

--- a/enemytarget/tsconfig.json
+++ b/enemytarget/tsconfig.json
@@ -1,40 +1,35 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "noImplicitAny": true,
-        "removeComments": false,
-        "outDir": "./tmp",
-        "sourceMap": false,
-        "jsx": "react"
-    },
-    "formatCodeOptions": {
-        "indentSize": 2,
-        "tabSize": 2,
-        "newLineCharacter": "\r\n",
-        "convertTabsToSpaces": true,
-        "insertSpaceAfterCommaDelimiter": true,
-        "insertSpaceAfterSemicolonInForStatements": true,
-        "insertSpaceBeforeAndAfterBinaryOperators": true,
-        "insertSpaceAfterKeywordsInControlFlowStatements": true,
-        "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-        "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
-        "placeOpenBraceOnNewLineForFunctions": false,
-        "placeOpenBraceOnNewLineForControlBlocks": false
-    },
-    "compileOnSave": false,
-    "buildOnSave": false,
-    "filesGlob": [
-        "./src/**/*.ts",
-        "./src/**/*.tsx"
-    ],
-    "files": [
-        "./src/tsd/react/react-dom.d.ts",
-        "./src/tsd/react/react.d.ts",
-        "./src/tsd/tsd.d.ts",
-        "./src/ts/main.tsx"
-    ],
-    "exclude": [],
-    "atom": {
-        "rewriteTsconfig": true
-    }
+  "compilerOptions": {
+    "target": "es6",
+    "noImplicitAny": true,
+    "removeComments": false,
+    "outDir": "./tmp",
+    "sourceMap": false,
+    "jsx": "react"
+  },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2,
+    "newLineCharacter": "\r\n",
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "filesGlob": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/errormessages/tsconfig.json
+++ b/errormessages/tsconfig.json
@@ -27,10 +27,9 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "files": [
-    "src/tsd/react/react.d.ts",
-    "src/tsd/tsd.d.ts",
-    "src/ts/main.tsx"
-  ],
-  "exclude": []
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/facebook/tsconfig.json
+++ b/facebook/tsconfig.json
@@ -1,36 +1,35 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "noImplicitAny": true,
-        "removeComments": false,
-        "outDir": "./tmp",
-        "sourceMap": false,
-        "jsx": "react"
-    },
-    "formatCodeOptions": {
-        "indentSize": 2,
-        "tabSize": 2,
-        "newLineCharacter": "\r\n",
-        "convertTabsToSpaces": true,
-        "insertSpaceAfterCommaDelimiter": true,
-        "insertSpaceAfterSemicolonInForStatements": true,
-        "insertSpaceBeforeAndAfterBinaryOperators": true,
-        "insertSpaceAfterKeywordsInControlFlowStatements": true,
-        "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-        "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
-        "placeOpenBraceOnNewLineForFunctions": false,
-        "placeOpenBraceOnNewLineForControlBlocks": false
-    },
-    "compileOnSave": false,
-    "buildOnSave": false,
-    "filesGlob": [
-        "./src/**/*.ts",
-        "./src/**/*.tsx"
-    ],
-    "files": [
-        "src/tsd/react/react.d.ts",
-        "src/tsd/tsd.d.ts",
-        "src/ts/main.tsx"
-    ],
-    "exclude": []
+  "compilerOptions": {
+    "target": "es6",
+    "noImplicitAny": true,
+    "removeComments": false,
+    "outDir": "./tmp",
+    "sourceMap": false,
+    "jsx": "react"
+  },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2,
+    "newLineCharacter": "\r\n",
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "filesGlob": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/friendlytarget/src/index.html
+++ b/friendlytarget/src/index.html
@@ -6,7 +6,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <head>
   <meta charset="UTF-8">
   <title>wounds friendly</title>
-  <link rel="stylesheet" href="../../interface-lib/cu-components/cu-components.css">
+  <link rel="stylesheet" href="../../interface-lib/camelot-unchained/camelot-unchained.css">
   <link rel="stylesheet" href="css/friendlytarget.css">
 </head>
 <body>

--- a/friendlytarget/src/sass/main.scss
+++ b/friendlytarget/src/sass/main.scss
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-@import "../../node_modules/camelot-unchained/lib/sass/main";
+@import "../../node_modules/camelot-unchained/lib/styles/window/woundsframe/woundsframe";
 
 body {
   @include wounds-body(90%);
@@ -13,4 +13,3 @@ body {
 #cse-ui-wounds {
   @include wounds-base(rgba(0, 0, 80, 0.7));
 }
- 

--- a/friendlytarget/tsconfig.json
+++ b/friendlytarget/tsconfig.json
@@ -27,14 +27,9 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "files": [
-    "./src/tsd/react/react-dom.d.ts",
-    "./src/tsd/react/react.d.ts",
-    "./src/tsd/tsd.d.ts",
-    "./src/ts/main.tsx"
-  ],
+  "files": [],
   "exclude": [],
   "atom": {
-    "rewriteTsconfig": true
+    "rewriteTsconfig": false
   }
 }

--- a/injuries/src/index.html
+++ b/injuries/src/index.html
@@ -6,7 +6,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <head>
   <meta charset="UTF-8">
   <title>Injuries</title>
-  <link rel="stylesheet" href="../../interface-lib/cu-components/cu-components.css">
+  <link rel="stylesheet" href="../../interface-lib/camelot-unchained/components/components.css">
   <link rel="stylesheet" href="css/injuries.css">
 </head>
 <body>

--- a/injuries/tsconfig.json
+++ b/injuries/tsconfig.json
@@ -27,10 +27,9 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "files": [
-    "src/tsd/react/react.d.ts",
-    "src/tsd/tsd.d.ts",
-    "src/ts/main.tsx"
-  ],
-  "exclude": []
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/kos/tsconfig.json
+++ b/kos/tsconfig.json
@@ -1,36 +1,35 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "noImplicitAny": true,
-        "removeComments": false,
-        "outDir": "./tmp",
-        "sourceMap": false,
-        "jsx": "react"
-    },
-    "formatCodeOptions": {
-        "indentSize": 2,
-        "tabSize": 2,
-        "newLineCharacter": "\r\n",
-        "convertTabsToSpaces": true,
-        "insertSpaceAfterCommaDelimiter": true,
-        "insertSpaceAfterSemicolonInForStatements": true,
-        "insertSpaceBeforeAndAfterBinaryOperators": true,
-        "insertSpaceAfterKeywordsInControlFlowStatements": true,
-        "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-        "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
-        "placeOpenBraceOnNewLineForFunctions": false,
-        "placeOpenBraceOnNewLineForControlBlocks": false
-    },
-    "compileOnSave": false,
-    "buildOnSave": false,
-    "filesGlob": [
-        "./src/**/*.ts",
-        "./src/**/*.tsx"
-    ],
-    "files": [
-        "src/tsd/react/react.d.ts",
-        "src/tsd/tsd.d.ts",
-        "src/ts/main.tsx"
-    ],
-    "exclude": []
+  "compilerOptions": {
+    "target": "es6",
+    "noImplicitAny": true,
+    "removeComments": false,
+    "outDir": "./tmp",
+    "sourceMap": false,
+    "jsx": "react"
+  },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2,
+    "newLineCharacter": "\r\n",
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "filesGlob": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/twitter/tsconfig.json
+++ b/twitter/tsconfig.json
@@ -1,36 +1,35 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "noImplicitAny": true,
-        "removeComments": false,
-        "outDir": "./tmp",
-        "sourceMap": false,
-        "jsx": "react"
-    },
-    "formatCodeOptions": {
-        "indentSize": 2,
-        "tabSize": 2,
-        "newLineCharacter": "\r\n",
-        "convertTabsToSpaces": true,
-        "insertSpaceAfterCommaDelimiter": true,
-        "insertSpaceAfterSemicolonInForStatements": true,
-        "insertSpaceBeforeAndAfterBinaryOperators": true,
-        "insertSpaceAfterKeywordsInControlFlowStatements": true,
-        "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-        "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
-        "placeOpenBraceOnNewLineForFunctions": false,
-        "placeOpenBraceOnNewLineForControlBlocks": false
-    },
-    "compileOnSave": false,
-    "buildOnSave": false,
-    "filesGlob": [
-        "./src/**/*.ts",
-        "./src/**/*.tsx"
-    ],
-    "files": [
-        "src/tsd/react/react.d.ts",
-        "src/tsd/tsd.d.ts",
-        "src/ts/main.tsx"
-    ],
-    "exclude": []
+  "compilerOptions": {
+    "target": "es6",
+    "noImplicitAny": true,
+    "removeComments": false,
+    "outDir": "./tmp",
+    "sourceMap": false,
+    "jsx": "react"
+  },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2,
+    "newLineCharacter": "\r\n",
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "filesGlob": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/watermark/tsconfig.json
+++ b/watermark/tsconfig.json
@@ -1,36 +1,35 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "noImplicitAny": true,
-        "removeComments": false,
-        "outDir": "./tmp",
-        "sourceMap": false,
-        "jsx": "react"
-    },
-    "formatCodeOptions": {
-        "indentSize": 2,
-        "tabSize": 2,
-        "newLineCharacter": "\r\n",
-        "convertTabsToSpaces": true,
-        "insertSpaceAfterCommaDelimiter": true,
-        "insertSpaceAfterSemicolonInForStatements": true,
-        "insertSpaceBeforeAndAfterBinaryOperators": true,
-        "insertSpaceAfterKeywordsInControlFlowStatements": true,
-        "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-        "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
-        "placeOpenBraceOnNewLineForFunctions": false,
-        "placeOpenBraceOnNewLineForControlBlocks": false
-    },
-    "compileOnSave": false,
-    "buildOnSave": false,
-    "filesGlob": [
-        "./src/**/*.ts",
-        "./src/**/*.tsx"
-    ],
-    "files": [
-        "src/tsd/react/react.d.ts",
-        "src/tsd/tsd.d.ts",
-        "src/ts/main.tsx"
-    ],
-    "exclude": []
+  "compilerOptions": {
+    "target": "es6",
+    "noImplicitAny": true,
+    "removeComments": false,
+    "outDir": "./tmp",
+    "sourceMap": false,
+    "jsx": "react"
+  },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2,
+    "newLineCharacter": "\r\n",
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "filesGlob": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }

--- a/wounds/tsconfig.json
+++ b/wounds/tsconfig.json
@@ -27,10 +27,9 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "files": [
-    "src/tsd/react/react.d.ts",
-    "src/tsd/tsd.d.ts",
-    "src/ts/main.tsx"
-  ],
-  "exclude": []
+  "files": [],
+  "exclude": [],
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }


### PR DESCRIPTION
Have cleaned up all `tsconfig.json` files as `atom-typescript` now allows us to disable rewriting the files parameter on tsconfig. Atom Typescript will still function correctly, as it has the `filesGlob` parameter.

Have also migrated references for `../../interface-lib/cu-components/cu-components.css` to `../../interface-lib/camelot-unchained/camelot-unchained.css` to match the updates in client library ( https://github.com/CUModSquad/Camelot-Unchained-Client-Library/pull/9 )

There will be improvements made going forward regarding SASS imports, but this will require some updates on client library and potentially the build tools.

**This PR should only be merged once a new build of `camelot-unchained` is published to npm.**
